### PR TITLE
Allow to search through parent node_modules folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@0xcert/ethereum-erc721": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@0xcert/ethereum-erc721/-/ethereum-erc721-2.0.0.tgz",
+      "integrity": "sha512-E4rt0OxUx82uwsOG2kYqfs3vpM4nLp9n3+39KQthGlAyJfZxHYepWTaPuPLbObMCFEZoH+BvkgAQ0zMU2nnlKw==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -786,6 +792,14 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -983,6 +997,14 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-installed-path": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/get-installed-path/-/get-installed-path-4.0.8.tgz",
+      "integrity": "sha512-PmANK1xElIHlHH2tXfOoTnSDUjX1X3GvKK6ZyLbUnSCCn1pADwu67eVWttuPzJWrXDDT2MfO6uAaKILOFfitmA==",
+      "requires": {
+        "global-modules": "1.0.0"
+      }
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -1013,6 +1035,28 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -1105,6 +1149,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -1168,6 +1220,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "6.3.1",
@@ -1278,11 +1335,15 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -1968,6 +2029,11 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2171,6 +2237,15 @@
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -2592,7 +2667,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
     "coveralls": "^3.0.3",
     "eslint": "^5.16.0",
     "mocha": "^6.1.4",
-    "nyc": "^14.1.0"
+    "nyc": "^14.1.0",
+    "@0xcert/ethereum-erc721": "2.0.0"
   },
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.19.0",
+    "get-installed-path": "~4.0.8"
   }
 }

--- a/test/contracts/ImportFromParentNodeModules.sol
+++ b/test/contracts/ImportFromParentNodeModules.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.5.6;
+
+import "@0xcert/ethereum-erc721/src/contracts/ownership/ownable.sol";
+
+contract ImportFromParentNodeModules is Ownable {
+}

--- a/test/contracts/straightened/ImportFromParentNodeModules.sol
+++ b/test/contracts/straightened/ImportFromParentNodeModules.sol
@@ -1,0 +1,68 @@
+pragma solidity 0.5.6;
+
+/**
+ * @dev The contract has an owner address, and provides basic authorization control whitch
+ * simplifies the implementation of user permissions. This contract is based on the source code at:
+ * https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/ownership/Ownable.sol
+ */
+contract Ownable
+{
+  
+  /**
+   * @dev Error constants.
+   */
+  string public constant NOT_OWNER = "018001";
+  string public constant ZERO_ADDRESS = "018002";
+
+  /**
+   * @dev Current owner address.
+   */
+  address public owner;
+
+  /**
+   * @dev An event which is triggered when the owner is changed.
+   * @param previousOwner The address of the previous owner.
+   * @param newOwner The address of the new owner.
+   */
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
+
+  /**
+   * @dev The constructor sets the original `owner` of the contract to the sender account.
+   */
+  constructor()
+    public
+  {
+    owner = msg.sender;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner()
+  {
+    require(msg.sender == owner, NOT_OWNER);
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param _newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(
+    address _newOwner
+  )
+    public
+    onlyOwner
+  {
+    require(_newOwner != address(0), ZERO_ADDRESS);
+    emit OwnershipTransferred(owner, _newOwner);
+    owner = _newOwner;
+  }
+
+}
+
+contract ImportFromParentNodeModules is Ownable {
+}

--- a/test/package.json
+++ b/test/package.json
@@ -12,6 +12,6 @@
   "author": "Aniket-Engg",
   "license": "MIT",
   "dependencies": {
-    "openzeppelin-solidity": "^2.2.0"
+    "openzeppelin-solidity": "2.2.0"
   }
 }

--- a/test/straighten.js
+++ b/test/straighten.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Straightener = require('../'),
-  expect  = require('chai').expect,
+  expect = require('chai').expect,
   fs = require('fs');
 
 describe('sol-straightener', () => {
@@ -13,9 +13,9 @@ describe('sol-straightener', () => {
   });
 
   it('Fails for contract with non existing file import', async () => {
-    try{
+    try {
       await Straightener.straighten(__dirname + '/contracts/SampleWithImportNotExisting.sol');
-    }catch(error){
+    } catch (error) {
       expect(error.message).to.include('no such file or directory');
     }
   });
@@ -35,7 +35,13 @@ describe('sol-straightener', () => {
   it('Contract with imports from node_modules', async () => {
     const strtnFile = await Straightener.straighten(__dirname + '/contracts/ImportFromNodeModules.sol');
     const strtnContent = fs.readFileSync(__dirname + '/contracts/straightened/ImportFromNodeModules.sol');
-    // expect(Buffer.from(strtnFile)).to.deep.equal(strtnContent);
+    expect(Buffer.from(strtnFile)).to.deep.equal(strtnContent);
+  });
+
+  it('Contract with imports from parent node_modules', async () => {
+    const strtnFile = await Straightener.straighten(__dirname + '/contracts/ImportFromParentNodeModules.sol');
+    const strtnContent = fs.readFileSync(__dirname + '/contracts/straightened/ImportFromParentNodeModules.sol');
+    expect(Buffer.from(strtnFile)).to.deep.equal(strtnContent);
   });
 
   it('Contract with multiple imports from Github', async () => {

--- a/utils/file.js
+++ b/utils/file.js
@@ -19,11 +19,8 @@ const getNodeModulesFolders = async (dir) => {
   const folders = [];
   for (let partIdx = 0; partIdx < parts.length; partIdx++) {
     const part = parts[partIdx];
-    if (part === '') {
-      continue;
-    }
 
-    if (folders.length == 0) {
+    if (folders.length === 0) {
       folders.push(path.join(path.sep, part, 'node_modules'));
     }
     else {

--- a/utils/file.js
+++ b/utils/file.js
@@ -3,22 +3,52 @@
 const path = require('path'),
   { execSync } = require('child_process'),
   axios = require('axios'),
-  fs = require('fs');
+  fs = require('fs'),
+  { getInstalledPath } = require('get-installed-path');
 
 const regEx = {
-  pragma  :   /(pragma solidity (.+?);)/g,
-  import  :   /import ['"](.+?)['"];/g,
-  github  :   /^(https?:\/\/)?(www.)?github.com\/([^/]*\/[^/]*)\/(.*)/,
+  pragma: /(pragma solidity (.+?);)/g,
+  import: /import ['"](.+?)['"];/g,
+  github: /^(https?:\/\/)?(www.)?github.com\/([^/]*\/[^/]*)\/(.*)/,
 };
 
 let processedFiles = [];
 
+const getNodeModulesFolders = async (dir) => {
+  const parts = path.dirname(dir).split(path.sep);
+  const folders = [];
+  for (let partIdx = 0; partIdx < parts.length; partIdx++) {
+    const part = parts[partIdx];
+    if (part === '') {
+      continue;
+    }
+
+    if (folders.length == 0) {
+      folders.push(path.join(path.sep, part, 'node_modules'));
+    }
+    else {
+      folders.push(path.join(path.dirname(folders[partIdx - 1]), part, 'node_modules'));
+    }
+  }
+
+  const rootNodeModules = (await execSync('npm root', { cwd: dir })).toString().trim();
+
+  return [...folders.reverse(), rootNodeModules];
+};
+
+const getNodeModulePath = async (name, { cwd }) => {
+  return getInstalledPath(name, {
+    paths: await getNodeModulesFolders(cwd),
+    cwd,
+  });
+};
+
 const processFile = async (file, fromGithub, root = false) => {
-  try{
-    if(root)
+  try {
+    if (root)
       processedFiles = [];
 
-    if(processedFiles.indexOf(file) !== -1)
+    if (processedFiles.indexOf(file) !== -1)
       return;
 
     processedFiles.push(file);
@@ -26,7 +56,7 @@ const processFile = async (file, fromGithub, root = false) => {
     let contents;
     let imports;
 
-    if(fromGithub){
+    if (fromGithub) {
       const metadata = regEx.github.exec(file);
       const url = 'https://api.github.com/repos/' + metadata[3] + '/contents/' + metadata[4];
       axios.defaults.headers.post['User-Agent'] = 'sol-straightener';
@@ -34,8 +64,7 @@ const processFile = async (file, fromGithub, root = false) => {
       contents = contents.replace(regEx.pragma, '').trim();
       imports = await processImports(file, contents, path.dirname(metadata[0]));
     }
-    else
-    {
+    else {
       contents = fs.readFileSync(file, { encoding: 'utf-8' });
       contents = contents.replace(regEx.pragma, '').trim();
       imports = await processImports(file, contents);
@@ -47,29 +76,29 @@ const processFile = async (file, fromGithub, root = false) => {
     result += contents;
     return result;
   }
-  catch(error){
+  catch (error) {
     throw error;
   }
 };
 
 const processImports = async (file, content, githubPrefix = false) => {
-  try{
-    let group='';
+  try {
+    let group = '';
     const result = [];
     let fileContents;
     regEx.import.exec(''); // Resetting state of RegEx
     while (group = regEx.import.exec(content)) {
       let importFile = group[1];
-      if(githubPrefix)
+      if (githubPrefix)
         importFile = path.join(githubPrefix, importFile);   // for imports in github file
 
-      if(importFile.substring(0, 10) == 'github.com'){
+      if (importFile.substring(0, 10) == 'github.com') {
         fileContents = await processFile(importFile, true);
-      }else{
+      } else {
         let filePath = path.join(path.dirname(file), importFile);
-        if(!fs.existsSync(filePath)){
-          const nodeModulesPath = (await execSync('npm root', { cwd: path.dirname(file) })).toString().trim();
-          filePath = path.join(nodeModulesPath, importFile);
+        if (!fs.existsSync(filePath)) {
+          const nodeModulesPath = await getNodeModulePath(path.dirname(importFile), { cwd: path.dirname(file) });
+          filePath = path.join(nodeModulesPath, path.basename(importFile));
         }
         filePath = path.normalize(filePath);
         fileContents = await processFile(filePath, false);
@@ -80,7 +109,7 @@ const processImports = async (file, content, githubPrefix = false) => {
     }
     return result;
   }
-  catch(error){
+  catch (error) {
     throw error;
   }
 };


### PR DESCRIPTION
It is quite often that a repo contains a lot of subprojects (packages) and uses workspaces (like in yarn/lerna).

Updated approach allows to scan not only in root node_modules folder but also parent node_modules folders in order to find imported smart contracts.